### PR TITLE
Add proxy support

### DIFF
--- a/src/Auth/OnlineFederation.php
+++ b/src/Auth/OnlineFederation.php
@@ -247,6 +247,10 @@ XML;
             curl_setopt( $cURLHandle, CURLOPT_SSL_VERIFYHOST, 0 );
         }
 
+        if( $this->settings->proxy ) {
+          curl_setopt($cURLHandle, CURLOPT_PROXY, $this->settings->proxy);
+        }
+
         curl_setopt( $cURLHandle, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1 );
         curl_setopt( $cURLHandle, CURLOPT_HTTPHEADER, [ 'Content-Type: application/x-www-form-urlencoded' ] );
         curl_setopt( $cURLHandle, CURLOPT_POST, 1 );

--- a/src/Auth/OnlineFederation.php
+++ b/src/Auth/OnlineFederation.php
@@ -248,7 +248,7 @@ XML;
         }
 
         if( $this->settings->proxy ) {
-          curl_setopt($cURLHandle, CURLOPT_PROXY, $this->settings->proxy);
+          curl_setopt( $cURLHandle, CURLOPT_PROXY, $this->settings->proxy );
         }
 
         curl_setopt( $cURLHandle, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1 );

--- a/src/Client.php
+++ b/src/Client.php
@@ -1059,6 +1059,10 @@ class Client extends AbstractClient {
           curl_setopt( $cURLHandle, CURLOPT_SSL_VERIFYHOST, 0 );
         }
 
+        if( $this->settings->proxy ) {
+          curl_setopt( $cURLHandle, CURLOPT_PROXY, $this->settings->proxy );
+        }
+
         curl_setopt( $cURLHandle, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1 );
         curl_setopt( $cURLHandle, CURLOPT_HTTPHEADER, $headers );
         curl_setopt( $cURLHandle, CURLOPT_POST, 1 );
@@ -1953,6 +1957,10 @@ class Client extends AbstractClient {
             if ( $this->settings->ignoreSslErrors ) {
                 curl_setopt( $wsdlCurl, CURLOPT_SSL_VERIFYPEER, 0 );
                 curl_setopt( $wsdlCurl, CURLOPT_SSL_VERIFYHOST, 0 );
+            }
+
+            if( $this->settings->proxy ) {
+              curl_setopt( $wsdlCurl, CURLOPT_PROXY, $this->settings->proxy );
             }
 
             $importXML = curl_exec( $wsdlCurl );

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -151,6 +151,13 @@ class Settings {
      */
     public $cache = array( "server" => "localhost", "port" => 11211 );
 
+  /**
+   * Proxy with port.
+   *
+   * @var string
+   */
+    public $proxy;
+
     /**
      * List of CRM regions
      *
@@ -211,6 +218,7 @@ class Settings {
         $this->organizationUniqueName = ( isset( $settings["organizationUniqueName"] ) ) ? $settings["organizationUniqueName"] : null;
         $this->organizationId         = ( isset( $settings["organizationId"] ) ) ? $settings["organizationId"] : null;
         $this->organizationVersion    = ( isset( $settings["organizationVersion"] ) ) ? $settings["organizationVersion"] : null;
+        $this->proxy    = ( isset( $settings["proxy"] ) ) ? $settings["proxy"] : null;
 
         if ( $this->authMode === 'OnlineFederation' ) {
             $crmRegionId     = $serverHostParts[1];


### PR DESCRIPTION
Add proxy support by adding a "proxy" property to the $settings array.

Example : 

```
$settings = [
      'serverUrl' => 'https://xxxxxx.crmX.dynamics.com',
      'username' => 'xxxxxxxxxxxxxxxxxxxxxxxxxxxx',
      'password' => 'xxxxxxxxxxxxxxxxxxxxxxxxxxxx',
      'authMode' => 'OnlineFederation',
      'proxy' => 'your_proxy_host:your_proxy_port',
    ];

$serviceSettings = new Settings($settings);
```